### PR TITLE
sed compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,6 @@
 **Note:**
 
 1. Please use this command to check whether tmux is able to find fzf [#1](https://github.com/sainnhe/tmux-fzf/issues/1): `tmux run-shell -b 'command -v fzf'`
-2. Currently this plugin is only compatible with GNU sed. Other sed variants such as Mac OS sed or FreeBSD sed are not supported. You need to ensure that this plugin is using GNU sed(see [#5](https://github.com/sainnhe/tmux-fzf/issues/5) for steps to install GNU sed on Mac OS).
-
-If you don't want to make GNU sed the system default, but instead customize the executable path, then add this line to your `~/.tmux.conf`
-
-```tmux
-TMUX_FZF_SED="/path/to/sed"
-```
 
 ## Install via [TPM](https://github.com/tmux-plugins/tpm/)
 

--- a/main.sh
+++ b/main.sh
@@ -1,10 +1,6 @@
 #!/usr/bin/env bash
 
 TMUX_FZF_SED="${TMUX_FZF_SED:-sed}"
-if [[ "$($TMUX_FZF_SED --version 2>/dev/null | head -n 1 | grep -o GNU)" != "GNU" ]]; then
-    tmux run-shell -b 'echo "Unable to find executable GNU sed."'
-    exit 1
-fi
 CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 if [[ -z "$TMUX_FZF_MENU" ]]; then

--- a/scripts/command.sh
+++ b/scripts/command.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 TMUX_FZF_SED="${TMUX_FZF_SED:-sed}"
-FZF_DEFAULT_OPTS=$(echo $FZF_DEFAULT_OPTS | $TMUX_FZF_SED -r -e '$a --header="select a command"')
+FZF_DEFAULT_OPTS=$(echo $FZF_DEFAULT_OPTS | $TMUX_FZF_SED -E -e '$a --header="select a command"')
 CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 TARGET_ORIGIN=$(tmux list-commands)

--- a/scripts/keybinding.sh
+++ b/scripts/keybinding.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 TMUX_FZF_SED="${TMUX_FZF_SED:-sed}"
-FZF_DEFAULT_OPTS=$(echo $FZF_DEFAULT_OPTS | $TMUX_FZF_SED -r -e '$a --header="select a key binding"')
+FZF_DEFAULT_OPTS=$(echo $FZF_DEFAULT_OPTS | $TMUX_FZF_SED -E -e '$a --header="select a key binding"')
 CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 TARGET_ORIGIN=$(tmux list-keys | $TMUX_FZF_SED '1i [cancel]' | eval "$CURRENT_DIR/.fzf-tmux $TMUX_FZF_OPTIONS")
@@ -9,7 +9,7 @@ TARGET_ORIGIN=$(tmux list-keys | $TMUX_FZF_SED '1i [cancel]' | eval "$CURRENT_DI
 [[ "$TARGET_ORIGIN" == "[cancel]" || -z "$TARGET_ORIGIN" ]] && exit
 if [[ -n $(echo "$TARGET_ORIGIN" | grep -o "copy-mode") && -z $(echo "$TARGET_ORIGIN" | grep -o "prefix") ]]; then
     tmux copy-mode
-    echo "$TARGET_ORIGIN" | $TMUX_FZF_SED -r 's/^.{46}//g' | xargs tmux
+    echo "$TARGET_ORIGIN" | $TMUX_FZF_SED -E 's/^.{46}//g' | xargs tmux
 else
-    echo "$TARGET_ORIGIN" | $TMUX_FZF_SED -r 's/^.{46}//g' | xargs tmux
+    echo "$TARGET_ORIGIN" | $TMUX_FZF_SED -E 's/^.{46}//g' | xargs tmux
 fi

--- a/scripts/pane.sh
+++ b/scripts/pane.sh
@@ -11,7 +11,7 @@ else
     PANES=$(tmux list-panes -a -F "#S:#{window_index}.#{pane_index}: $TMUX_FZF_PANE_FORMAT")
 fi
 
-FZF_DEFAULT_OPTS=$(echo $FZF_DEFAULT_OPTS | $TMUX_FZF_SED -r -e '$a --header="select an action"')
+FZF_DEFAULT_OPTS=$(echo $FZF_DEFAULT_OPTS | $TMUX_FZF_SED -E -e '$a --header="select an action"')
 if [[ -z "$1" ]]; then
     ACTION=$(printf "switch\nbreak\njoin\nswap\nlayout\nkill\nresize\n[cancel]" | eval "$CURRENT_DIR/.fzf-tmux $TMUX_FZF_OPTIONS")
 else
@@ -20,16 +20,16 @@ fi
 
 [[ "$ACTION" == "[cancel]" || -z "$ACTION" ]] && exit
 if [[ "$ACTION" == "layout" ]]; then
-    FZF_DEFAULT_OPTS=$(echo $FZF_DEFAULT_OPTS | $TMUX_FZF_SED -r -e '$a --header="select a layout"')
+    FZF_DEFAULT_OPTS=$(echo $FZF_DEFAULT_OPTS | $TMUX_FZF_SED -E -e '$a --header="select a layout"')
     TARGET_ORIGIN=$(printf "even-horizontal\neven-vertical\nmain-horizontal\nmain-vertical\ntiled\n[cancel]" | eval "$CURRENT_DIR/.fzf-tmux $TMUX_FZF_OPTIONS")
     [[ "$TARGET_ORIGIN" == "[cancel]" || -z "$TARGET_ORIGIN" ]] && exit
     tmux select-layout "$TARGET_ORIGIN"
 elif [[ "$ACTION" == "resize" ]]; then
-    FZF_DEFAULT_OPTS=$(echo $FZF_DEFAULT_OPTS | $TMUX_FZF_SED -r -e '$a --header="select direction"')
+    FZF_DEFAULT_OPTS=$(echo $FZF_DEFAULT_OPTS | $TMUX_FZF_SED -E -e '$a --header="select direction"')
     TARGET_ORIGIN=$(printf "left\nright\nup\ndown\n[cancel]" | eval "$CURRENT_DIR/.fzf-tmux $TMUX_FZF_OPTIONS")
     [[ "$TARGET_ORIGIN" == "[cancel]" || -z "$TARGET_ORIGIN" ]] && exit
     if [[ "$TARGET_ORIGIN" == "left" || "$TARGET_ORIGIN" == "right" ]]; then
-        FZF_DEFAULT_OPTS=$(echo $FZF_DEFAULT_OPTS | $TMUX_FZF_SED -r -e '$a --header="cells to be adjusted"')
+        FZF_DEFAULT_OPTS=$(echo $FZF_DEFAULT_OPTS | $TMUX_FZF_SED -E -e '$a --header="cells to be adjusted"')
         SIZE=$(printf "1\n2\n3\n5\n10\n20\n30\n[cancel]" | eval "$CURRENT_DIR/.fzf-tmux $TMUX_FZF_OPTIONS")
         [[ "$SIZE" == "[cancel]" || -z "$SIZE" ]] && exit
         if [[ "$TARGET_ORIGIN" == "left" ]]; then
@@ -38,7 +38,7 @@ elif [[ "$ACTION" == "resize" ]]; then
             tmux resize-pane -R "$SIZE"
         fi
     elif [[ "$TARGET_ORIGIN" == "up" || "$TARGET_ORIGIN" == "down" ]]; then
-        FZF_DEFAULT_OPTS=$(echo $FZF_DEFAULT_OPTS | $TMUX_FZF_SED -r -e '$a --header="lines to be adjusted"')
+        FZF_DEFAULT_OPTS=$(echo $FZF_DEFAULT_OPTS | $TMUX_FZF_SED -E -e '$a --header="lines to be adjusted"')
         SIZE=$(printf "1\n2\n3\n5\n10\n15\n20\n[cancel]" | eval "$CURRENT_DIR/.fzf-tmux $TMUX_FZF_OPTIONS")
         [[ "$SIZE" == "[cancel]" || -z "$SIZE" ]] && exit
         if [[ "$TARGET_ORIGIN" == "up" ]]; then
@@ -49,28 +49,28 @@ elif [[ "$ACTION" == "resize" ]]; then
     fi
 else
     if [[ "$ACTION" == "join" || "$ACTION" == "kill" ]]; then
-        FZF_DEFAULT_OPTS=$(echo $FZF_DEFAULT_OPTS | $TMUX_FZF_SED -r -e '$a --header="select target pane(s), press TAB to select multiple targets"')
+        FZF_DEFAULT_OPTS=$(echo $FZF_DEFAULT_OPTS | $TMUX_FZF_SED -E -e '$a --header="select target pane(s), press TAB to select multiple targets"')
     else
-        FZF_DEFAULT_OPTS=$(echo $FZF_DEFAULT_OPTS | $TMUX_FZF_SED -r -e '$a --header="select target pane"')
+        FZF_DEFAULT_OPTS=$(echo $FZF_DEFAULT_OPTS | $TMUX_FZF_SED -E -e '$a --header="select target pane"')
     fi
     if [[ "$ACTION" == "switch" || "$ACTION" == "join" ]]; then
         PANES=$(echo "$PANES" | grep -v "^$CURRENT_PANE")
         TARGET_ORIGIN=$(printf "%s\n[cancel]" "$PANES" | eval "$CURRENT_DIR/.fzf-tmux $TMUX_FZF_OPTIONS")
     else
         TARGET_ORIGIN=$(printf "[current]\n%s\n[cancel]" "$PANES" | eval "$CURRENT_DIR/.fzf-tmux $TMUX_FZF_OPTIONS")
-        TARGET_ORIGIN=$(echo "$TARGET_ORIGIN" | $TMUX_FZF_SED -r "s/\[current\]/$CURRENT_PANE_ORIGIN/")
+        TARGET_ORIGIN=$(echo "$TARGET_ORIGIN" | $TMUX_FZF_SED -E "s/\[current\]/$CURRENT_PANE_ORIGIN/")
     fi
     [[ "$TARGET_ORIGIN" == "[cancel]" || -z "$TARGET_ORIGIN" ]] && exit
     TARGET=$(echo "$TARGET_ORIGIN" | grep -o '^[[:alpha:]|[:digit:]]*:[[:digit:]]*\.[[:digit:]]*:' | $TMUX_FZF_SED 's/.$//g')
     if [[ "$ACTION" == "switch" ]]; then
-        echo "$TARGET" | $TMUX_FZF_SED -r 's/:.*//g' | xargs tmux switch-client -t
-        echo "$TARGET" | $TMUX_FZF_SED -r 's/\..*//g' | xargs tmux select-window -t
+        echo "$TARGET" | $TMUX_FZF_SED -E 's/:.*//g' | xargs tmux switch-client -t
+        echo "$TARGET" | $TMUX_FZF_SED -E 's/\..*//g' | xargs tmux select-window -t
         echo "$TARGET" | xargs tmux select-pane -t
     elif [[ "$ACTION" == "kill" ]]; then
         echo "$TARGET" | sort -r | xargs -i tmux kill-pane -t {}
     elif [[ "$ACTION" == "swap" ]]; then
         PANES=$(echo "$PANES" | grep -v "^$TARGET")
-        FZF_DEFAULT_OPTS=$(echo $FZF_DEFAULT_OPTS | $TMUX_FZF_SED -r -e '$a --header="select another target pane"')
+        FZF_DEFAULT_OPTS=$(echo $FZF_DEFAULT_OPTS | $TMUX_FZF_SED -E -e '$a --header="select another target pane"')
         TARGET_SWAP_ORIGIN=$(printf "%s\n[cancel]" "$PANES" | eval "$CURRENT_DIR/.fzf-tmux $TMUX_FZF_OPTIONS")
         [[ "$TARGET_SWAP_ORIGIN" == "[cancel]" || -z "$TARGET_SWAP_ORIGIN" ]] && exit
         TARGET_SWAP=$(echo "$TARGET_SWAP_ORIGIN" | grep -o '^[[:alpha:]|[:digit:]]*:[[:digit:]]*\.[[:digit:]]*:' | $TMUX_FZF_SED 's/.$//g')

--- a/scripts/session.sh
+++ b/scripts/session.sh
@@ -10,7 +10,7 @@ else
     SESSIONS=$(tmux list-sessions -F "#S: $TMUX_FZF_SESSION_FORMAT")
 fi
 
-FZF_DEFAULT_OPTS=$(echo $FZF_DEFAULT_OPTS | $TMUX_FZF_SED -r -e '$a --header="select an action"')
+FZF_DEFAULT_OPTS=$(echo $FZF_DEFAULT_OPTS | $TMUX_FZF_SED -E -e '$a --header="select an action"')
 if [[ -z "$1" ]]; then
     ACTION=$(printf "attach\ndetach\nrename\nkill\n[cancel]" | eval "$CURRENT_DIR/.fzf-tmux $TMUX_FZF_OPTIONS")
 else
@@ -20,9 +20,9 @@ fi
 [[ "$ACTION" == "[cancel]" || -z "$ACTION" ]] && exit
 if [[ "$ACTION" != "detach" ]]; then
     if [[ "$ACTION" == "kill" ]]; then
-        FZF_DEFAULT_OPTS=$(echo $FZF_DEFAULT_OPTS | $TMUX_FZF_SED -r -e '$a --header="select target session(s), press TAB to select multiple targets"')
+        FZF_DEFAULT_OPTS=$(echo $FZF_DEFAULT_OPTS | $TMUX_FZF_SED -E -e '$a --header="select target session(s), press TAB to select multiple targets"')
     else
-        FZF_DEFAULT_OPTS=$(echo $FZF_DEFAULT_OPTS | $TMUX_FZF_SED -r -e '$a --header="select target session"')
+        FZF_DEFAULT_OPTS=$(echo $FZF_DEFAULT_OPTS | $TMUX_FZF_SED -E -e '$a --header="select target session"')
     fi
     if [[ "$ACTION" == "attach" ]]; then
         TMUX_ATTACHED_SESSIONS=$(tmux list-sessions | grep 'attached' | grep -o '^[[:alpha:][:digit:]_-]*:' | $TMUX_FZF_SED 's/.$//g')
@@ -30,14 +30,14 @@ if [[ "$ACTION" != "detach" ]]; then
         TARGET_ORIGIN=$(printf "%s\n[cancel]" "$SESSIONS" | eval "$CURRENT_DIR/.fzf-tmux $TMUX_FZF_OPTIONS")
     else
         TARGET_ORIGIN=$(printf "[current]\n%s\n[cancel]" "$SESSIONS" | eval "$CURRENT_DIR/.fzf-tmux $TMUX_FZF_OPTIONS")
-        TARGET_ORIGIN=$(echo "$TARGET_ORIGIN" | $TMUX_FZF_SED -r "s/\[current\]/$CURRENT_SESSION_ORIGIN/")
+        TARGET_ORIGIN=$(echo "$TARGET_ORIGIN" | $TMUX_FZF_SED -E "s/\[current\]/$CURRENT_SESSION_ORIGIN/")
     fi
 else
     TMUX_ATTACHED_SESSIONS=$(tmux list-sessions | grep 'attached' | grep -o '^[[:alpha:][:digit:]_-]*:' | $TMUX_FZF_SED 's/.$//g')
     SESSIONS=$(echo "$SESSIONS" | grep "^$TMUX_ATTACHED_SESSIONS")
-    FZF_DEFAULT_OPTS=$(echo $FZF_DEFAULT_OPTS | $TMUX_FZF_SED -r -e '$a --header="select target session(s), press TAB to select multiple targets"')
+    FZF_DEFAULT_OPTS=$(echo $FZF_DEFAULT_OPTS | $TMUX_FZF_SED -E -e '$a --header="select target session(s), press TAB to select multiple targets"')
     TARGET_ORIGIN=$(printf "[current]\n%s\n[cancel]" "$SESSIONS" | eval "$CURRENT_DIR/.fzf-tmux $TMUX_FZF_OPTIONS")
-    TARGET_ORIGIN=$(echo "$TARGET_ORIGIN" | $TMUX_FZF_SED -r "s/\[current\]/$CURRENT_SESSION_ORIGIN/")
+    TARGET_ORIGIN=$(echo "$TARGET_ORIGIN" | $TMUX_FZF_SED -E "s/\[current\]/$CURRENT_SESSION_ORIGIN/")
 fi
 [[ "$TARGET_ORIGIN" == "[cancel]" || -z "$TARGET_ORIGIN" ]] && exit
 TARGET=$(echo "$TARGET_ORIGIN" | grep -o '^[[:alpha:][:digit:]_-]*:' | $TMUX_FZF_SED 's/.$//g')

--- a/scripts/window.sh
+++ b/scripts/window.sh
@@ -11,7 +11,7 @@ else
     WINDOWS=$(tmux list-windows -a -F "#S:#{window_index}: $TMUX_FZF_WINDOW_FORMAT")
 fi
 
-FZF_DEFAULT_OPTS=$(echo $FZF_DEFAULT_OPTS | $TMUX_FZF_SED -r -e '$a --header="select an action"')
+FZF_DEFAULT_OPTS=$(echo $FZF_DEFAULT_OPTS | $TMUX_FZF_SED -E -e '$a --header="select an action"')
 
 if [[ -z "$1" ]]; then
     ACTION=$(printf "switch\nlink\nmove\nswap\nrename\nkill\n[cancel]" | eval "$CURRENT_DIR/.fzf-tmux $TMUX_FZF_OPTIONS")
@@ -25,7 +25,7 @@ if [[ "$ACTION" == "link" ]]; then
     CUR_SES=$(tmux display-message -p | $TMUX_FZF_SED -e 's/^.//' -e 's/].*//')
     LAST_WIN_NUM=$(tmux list-windows | sort -r | $TMUX_FZF_SED '2,$d' | $TMUX_FZF_SED 's/:.*//')
     WINDOWS=$(echo "$WINDOWS" | grep -v "^$CUR_SES")
-    FZF_DEFAULT_OPTS=$(echo $FZF_DEFAULT_OPTS | $TMUX_FZF_SED -r -e '$a --header="select source window"')
+    FZF_DEFAULT_OPTS=$(echo $FZF_DEFAULT_OPTS | $TMUX_FZF_SED -E -e '$a --header="select source window"')
     SRC_WIN_ORIGIN=$(printf "%s\n[cancel]" "$WINDOWS" | eval "$CURRENT_DIR/.fzf-tmux $TMUX_FZF_OPTIONS")
     [[ "$SRC_WIN_ORIGIN" == "[cancel]" || -z "$SRC_WIN_ORIGIN" ]] && exit
     SRC_WIN=$(echo "$SRC_WIN_ORIGIN" | grep -o '^[[:alpha:]|[:digit:]]*:[[:digit:]]*:' | $TMUX_FZF_SED 's/.$//g')
@@ -35,20 +35,20 @@ elif [[ "$ACTION" == "move" ]]; then
     CUR_SES=$(tmux display-message -p | $TMUX_FZF_SED -e 's/^.//' -e 's/].*//')
     LAST_WIN_NUM=$(tmux list-windows | sort -r | $TMUX_FZF_SED '2,$d' | $TMUX_FZF_SED 's/:.*//')
     WINDOWS=$(echo "$WINDOWS" | grep -v "^$CUR_SES")
-    FZF_DEFAULT_OPTS=$(echo $FZF_DEFAULT_OPTS | $TMUX_FZF_SED -r -e '$a --header="select source window"')
+    FZF_DEFAULT_OPTS=$(echo $FZF_DEFAULT_OPTS | $TMUX_FZF_SED -E -e '$a --header="select source window"')
     SRC_WIN_ORIGIN=$(printf "%s\n[cancel]" "$WINDOWS" | eval "$CURRENT_DIR/.fzf-tmux $TMUX_FZF_OPTIONS")
     [[ "$SRC_WIN_ORIGIN" == "[cancel]" || -z "$SRC_WIN_ORIGIN" ]] && exit
     SRC_WIN=$(echo "$SRC_WIN_ORIGIN" | grep -o '^[[:alpha:]|[:digit:]]*:[[:digit:]]*:' | $TMUX_FZF_SED 's/.$//g')
     tmux move-window -a -s "$SRC_WIN" -t "$CUR_WIN"
 else
     if [[ "$ACTION" == "kill" ]]; then
-        FZF_DEFAULT_OPTS=$(echo $FZF_DEFAULT_OPTS | $TMUX_FZF_SED -r -e '$a --header="select target window(s), press TAB to select multiple targets"')
+        FZF_DEFAULT_OPTS=$(echo $FZF_DEFAULT_OPTS | $TMUX_FZF_SED -E -e '$a --header="select target window(s), press TAB to select multiple targets"')
     else
-        FZF_DEFAULT_OPTS=$(echo $FZF_DEFAULT_OPTS | $TMUX_FZF_SED -r -e '$a --header="select target window"')
+        FZF_DEFAULT_OPTS=$(echo $FZF_DEFAULT_OPTS | $TMUX_FZF_SED -E -e '$a --header="select target window"')
     fi
     if [[ "$ACTION" != "switch" ]]; then
         TARGET_ORIGIN=$(printf "[current]\n%s\n[cancel]" "$WINDOWS" | eval "$CURRENT_DIR/.fzf-tmux $TMUX_FZF_OPTIONS")
-        TARGET_ORIGIN=$(echo "$TARGET_ORIGIN" | $TMUX_FZF_SED -r "s/\[current\]/$CURRENT_WINDOW_ORIGIN/")
+        TARGET_ORIGIN=$(echo "$TARGET_ORIGIN" | $TMUX_FZF_SED -E "s/\[current\]/$CURRENT_WINDOW_ORIGIN/")
     else
         WINDOWS=$(echo "$WINDOWS" | grep -v "^$CURRENT_WINDOW")
         TARGET_ORIGIN=$(printf "%s\n[cancel]" "$WINDOWS" | eval "$CURRENT_DIR/.fzf-tmux $TMUX_FZF_OPTIONS")
@@ -61,7 +61,7 @@ else
         tmux command-prompt -I "rename-window -t $TARGET "
     elif [[ "$ACTION" == "swap" ]]; then
         WINDOWS=$(echo "$WINDOWS" | grep -v "^$TARGET")
-        FZF_DEFAULT_OPTS=$(echo $FZF_DEFAULT_OPTS | $TMUX_FZF_SED -r -e '$a --header="select another target window"')
+        FZF_DEFAULT_OPTS=$(echo $FZF_DEFAULT_OPTS | $TMUX_FZF_SED -E -e '$a --header="select another target window"')
         TARGET_SWAP_ORIGIN=$(printf "%s\n[cancel]" "$WINDOWS" | eval "$CURRENT_DIR/.fzf-tmux $TMUX_FZF_OPTIONS")
         [[ "$TARGET_SWAP_ORIGIN" == "[cancel]" || -z "$TARGET_SWAP_ORIGIN" ]] && exit
         TARGET_SWAP=$(echo "$TARGET_SWAP_ORIGIN" | grep -o '^[[:alpha:]|[:digit:]]*:[[:digit:]]*:' | $TMUX_FZF_SED 's/.$//g')


### PR DESCRIPTION
From GNU sed `sed --help`:
>    -E, -r, --regexp-extended
    use extended regular expressions in the script
    (for portability use POSIX -E).

For portability, `-E` should be used. If this is the only compatibility issue for macOS/BSD, then using `-E` instead of `-r` eliminates the need for users on those systems to install GNU sed, as was previously recommended in #5.

It seemed to work fine from some brief testing, but let me know if there is any breakage or there are additional blockers.