### PR TITLE
fix: more accurate filter for session names

### DIFF
--- a/scripts/session.sh
+++ b/scripts/session.sh
@@ -25,7 +25,7 @@ if [[ "$action" != "detach" ]]; then
     fi
     if [[ "$action" == "attach" ]]; then
         tmux_attached_sessions=$(tmux list-sessions | grep 'attached' | grep -o '^[[:alpha:][:digit:]_-]*:' | sed 's/.$//g')
-        sessions=$(echo "$sessions" | grep -v "^$tmux_attached_sessions")
+        sessions=$(echo "$sessions" | grep -v "^$tmux_attached_sessions: ")
         target_origin=$(printf "%s\n[cancel]" "$sessions" | eval "$CURRENT_DIR/.fzf-tmux $TMUX_FZF_OPTIONS")
     else
         target_origin=$(printf "[current]\n%s\n[cancel]" "$sessions" | eval "$CURRENT_DIR/.fzf-tmux $TMUX_FZF_OPTIONS")


### PR DESCRIPTION
Currently when searching sessions, sessions with name starting with the name of attached sessions will be filtered unexpectedly. For example, if session `project` is attached, sessions like `project_sub1` can't be selected even if it's not attached.

This PR fixes the problem by changing the `grep -v` command used to filter attached sessions.