### PR TITLE
Fix the exit status when copyq is not found

### DIFF
--- a/daemon.sh
+++ b/daemon.sh
@@ -2,6 +2,4 @@
 
 if [ -x "$(command -v copyq)" ]; then
     "$1/scripts/clipboard/clipster" -d &>/dev/null &
-else
-    exit
 fi


### PR DESCRIPTION
I fixed an error when there is no copyq.
Because the exit command sets the last exit status with no arguments.

#### Error message
`/home/yutakatay/.local/share/tmux/plugins/tmux-fzf/daemon.sh /home/yutakatay/.local/share/tmux/plugins/tmux-fzf' returned 1`

#### Link
- https://tldp.org/LDP/abs/html/exit-status.html