### PR TITLE
Make xargs invocations work for BSD/Darwin

### DIFF
--- a/scripts/.preview
+++ b/scripts/.preview
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-[ "$1" != '[cancel]' ] && [ "$1" != '[current]' ] && echo $1 | sed 's/: .*$//' | xargs -i tmux capture-pane -ep -t {}
+[ "$1" != '[cancel]' ] && [ "$1" != '[current]' ] && echo $1 | sed 's/: .*$//' | xargs tmux capture-pane -ep -t

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -17,4 +17,4 @@ target=$(printf "%s\n[cancel]" "$front_end_list" | eval "$TMUX_FZF_BIN $TMUX_FZF
 
 [[ "$target" == "[cancel]" || -z "$target" ]] && exit
 # get the next line in $TMUX_FZF_MENU and execute
-echo -e "$TMUX_FZF_MENU" | sed -n "/$target/{n;p;}" | xargs -I{} tmux -c {}
+echo -e "$TMUX_FZF_MENU" | sed -n "/$target/{n;p;}" | xargs tmux -c

--- a/scripts/pane.sh
+++ b/scripts/pane.sh
@@ -68,7 +68,7 @@ else
         echo "$target" | sed -E 's/\..*//g' | xargs tmux select-window -t
         echo "$target" | xargs tmux select-pane -t
     elif [[ "$action" == "kill" ]]; then
-        echo "$target" | sort -r | xargs -i tmux kill-pane -t {}
+        echo "$target" | sort -r | xargs tmux kill-pane -t
     elif [[ "$action" == "swap" ]]; then
         panes=$(echo "$panes" | grep -v "^$target")
         FZF_DEFAULT_OPTS=$(echo $FZF_DEFAULT_OPTS | sed -E -e '$a --header="Select another target pane."')
@@ -77,7 +77,7 @@ else
         target_swap=$(echo "$target_swap_origin" | sed 's/: .*//')
         tmux swap-pane -s "$target" -t "$target_swap"
     elif [[ "$action" == "join" ]]; then
-        echo "$target" | sort -r | xargs -i tmux move-pane -s {}
+        echo "$target" | sort -r | xargs tmux move-pane -s
     elif [[ "$action" == "break" ]]; then
         cur_ses=$(tmux display-message -p | sed -e 's/^.//' -e 's/].*//')
         last_win_num=$(tmux list-windows | sort -r | sed '2,$d' | sed 's/:.*//')

--- a/scripts/session.sh
+++ b/scripts/session.sh
@@ -44,9 +44,9 @@ target=$(echo "$target_origin" | grep -o '^[[:alpha:][:digit:]_-]*:' | sed 's/.$
 if [[ "$action" == "attach" ]]; then
     echo "$target" | xargs tmux switch-client -t
 elif [[ "$action" == "detach" ]]; then
-    echo "$target" | xargs -i tmux detach -s {}
+    echo "$target" | xargs tmux detach -s
 elif [[ "$action" == "kill" ]]; then
-    echo "$target" | sort -r | xargs -i tmux kill-session -t {}
+    echo "$target" | sort -r | xargs tmux kill-session -t
 elif [[ "$action" == "rename" ]]; then
     tmux command-prompt -I "rename-session -t $target "
 fi

--- a/scripts/window.sh
+++ b/scripts/window.sh
@@ -56,7 +56,7 @@ else
     [[ "$target_origin" == "[cancel]" || -z "$target_origin" ]] && exit
     target=$(echo "$target_origin" | sed 's/: .*//')
     if [[ "$action" == "kill" ]]; then
-        echo "$target" | sort -r | xargs -i tmux unlink-window -k -t {}
+        echo "$target" | sort -r | xargs tmux unlink-window -k -t
     elif [[ "$action" == "rename" ]]; then
         tmux command-prompt -I "rename-window -t $target "
     elif [[ "$action" == "swap" ]]; then


### PR DESCRIPTION
The -i parameter doesn't exist on those platforms, causing the preview window
to break:

% echo test_session:0.0 | xargs -i echo tmux capture-pane -ep -t '{}'
xargs: illegal option -- i
usage: xargs [-0opt] [-E eofstr] [-I replstr [-R replacements]] [-J replstr]
             [-L number] [-n number [-x]] [-P maxprocs] [-s size]
             [utility [argument ...]]

It should be safe to remove this parameter, as well as the associated replstr
{}, and still get the same result:

% echo test_session:0.0 | xargs -i echo tmux capture-pane -ep -t '{}'
tmux capture-pane -ep -t test_session:0.0
% echo test_session:0.0 | xargs echo tmux capture-pane -ep -t
tmux capture-pane -ep -t test_session:0.0