### PR TITLE
Fix filtering window list in "window switch"

### DIFF
--- a/scripts/window.sh
+++ b/scripts/window.sh
@@ -4,7 +4,7 @@ CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$CURRENT_DIR/.envs"
 
 current_window_origin=$(tmux display-message -p '#S:#I: #{window_name}')
-current_window=$(tmux display-message -p '#S:#I')
+current_window=$(tmux display-message -p '#S:#I:')
 if [[ -z "$TMUX_FZF_WINDOW_FORMAT" ]]; then
     windows=$(tmux list-windows -a)
 else


### PR DESCRIPTION
Current behaviour:
```
...
session:2: . . . 
...
session:21: . . .
session:22: . . .
...
```

When we have a window list like this, and our current window is `session:2: . . .`, all `session:2*:` windows are filtered out and it is impossible to switch to them.

---
Desired behaviour:
Only current window is filtered out.