### PR TITLE
Add `/` as a legal character in session name

### DIFF
--- a/scripts/session.sh
+++ b/scripts/session.sh
@@ -43,7 +43,7 @@ else
     target_origin=$(echo "$target_origin" | sed -E "s/\[current\]/$current_session:/")
 fi
 [[ "$target_origin" == "[cancel]" || -z "$target_origin" ]] && exit
-target=$(echo "$target_origin" | grep -o '^[[:alpha:][:digit:]_-]*:' | sed 's/.$//g')
+target=$(echo "$target_origin" | grep -o '^[[:alpha:][:digit:]/_-]*:' | sed 's/.$//g')
 if [[ "$action" == "attach" ]]; then
     echo "$target" | xargs tmux switch-client -t
 elif [[ "$action" == "detach" ]]; then


### PR DESCRIPTION
I found `tmux-fzf` this morning and it's amazing! Allows for exactly what I want - a key-bound popup to switch sessions 🎉 

Unfortunately the sessions switch didn't work. After some digging and putting `echo`s around in the script I found out that session name regex is the culprit.

I've been naming my sessions after paths of their roots, this sometimes contains slashes - makes working with monorepos easier.

Of course you might know about reasons not to add it to the plugin technical or philosophical -feel free to close that PR.

Thanks for building `tmux-fzf`!