### PR TITLE
Fix spaces in session/window names being passed incorrectly through xargs

### DIFF
--- a/scripts/pane.sh
+++ b/scripts/pane.sh
@@ -64,9 +64,9 @@ else
     [[ "$target_origin" == "[cancel]" || -z "$target_origin" ]] && exit
     target=$(echo "$target_origin" | sed 's/: .*//')
     if [[ "$action" == "switch" ]]; then
-        echo "$target" | sed -E 's/:.*//g' | xargs tmux switch-client -t
-        echo "$target" | sed -E 's/\..*//g' | xargs tmux select-window -t
-        echo "$target" | xargs tmux select-pane -t
+        echo "$target" | sed -E 's/:.*//g' | xargs -I{} tmux switch-client -t {}
+        echo "$target" | sed -E 's/\..*//g' | xargs -I{} tmux select-window -t {}
+        echo "$target" | xargs -I{} tmux select-pane -t {}
     elif [[ "$action" == "kill" ]]; then
         echo "$target" | sort -r | xargs -I{} tmux kill-pane -t {}
     elif [[ "$action" == "swap" ]]; then

--- a/scripts/window.sh
+++ b/scripts/window.sh
@@ -65,7 +65,7 @@ else
         target_swap=$(echo "$target_swap_origin" | sed 's/: .*//')
         tmux swap-pane -s "$target" -t "$target_swap"
     elif [[ "$action" == "switch" ]]; then
-        echo "$target" | sed 's/:.*//g' | xargs tmux switch-client -t
-        echo "$target" | xargs tmux select-window -t
+        echo "$target" | sed 's/:.*//g' | xargs -I{} tmux switch-client -t {}
+        echo "$target" | xargs -I{} tmux select-window -t {}
     fi
 fi


### PR DESCRIPTION
To reproduce the error that this fixes:

1. Create a session with a space in the name: `tmux new-session -t "test name"`
2. Switch to another session
3. Attempt to fuzzy switch back to that session and be greeted with error message resembling `'~/.config/tmux/plugins/tmux-fzf/scripts/window.sh switch' returned 123`

This PR fixes that issue.