### PR TITLE
Make 'tmux split-window' compatible with tmux 3.4

### DIFF
--- a/scripts/process.sh
+++ b/scripts/process.sh
@@ -29,17 +29,17 @@ _kill() { #{{{ _kill SIG PID USER
         kill -s $1 $2
     else
         if [ -x "$(command -v sudo)" ]; then
-            tmux split-window -v -p 30 -b -c '#{pane_current_path}' "bash -c 'sudo kill -s $1 $2'"
+            tmux split-window -v -l 30% -b -c '#{pane_current_path}' "bash -c 'sudo kill -s $1 $2'"
         elif [ -x "$(command -v doas)" ]; then
-            tmux split-window -v -p 30 -b -c '#{pane_current_path}' "bash -c 'doas kill -s $1 $2'"
+            tmux split-window -v -l 30% -b -c '#{pane_current_path}' "bash -c 'doas kill -s $1 $2'"
         fi
     fi
 } #}}}
 if [[ "$action" == "display" ]]; then
     if [[ "$(uname)" == "Linux" ]]; then
-        tmux split-window -v -p 50 -b -c '#{pane_current_path}' "top -p $pid"
+        tmux split-window -v -l 50% -b -c '#{pane_current_path}' "top -p $pid"
     else
-        tmux split-window -v -p 50 -b -c '#{pane_current_path}' "top -pid $pid"
+        tmux split-window -v -l 50% -b -c '#{pane_current_path}' "top -pid $pid"
     fi
 elif [[ "$action" == "tree" ]]; then
     pstree -p "$pid"

--- a/scripts/session.sh
+++ b/scripts/session.sh
@@ -20,7 +20,7 @@ fi
 [[ "$action" == "[cancel]" || -z "$action" ]] && exit
 if [[ "$action" != "detach" ]]; then
     if [[ "$action" == "new" ]]; then
-        tmux split-window -v -p 30 -b -c '#{pane_current_path}' \
+        tmux split-window -v -l 30% -b -c '#{pane_current_path}' \
             "bash -c 'printf \"Session Name: \" && read session_name && tmux new-session -d -s \"\$session_name\" && tmux switch-client -t \"\$session_name\"'"
         exit
     fi


### PR DESCRIPTION
Close #76 

---

I upgraded to tmux3.4 and then realized that the "new session" feature was not working. After some searching, I found https://github.com/tmux/tmux/issues/3836#issuecomment-1942216630, after applying the changes, it works again. I also tested this change on tmux3.2a and it works fine.

