### PR TITLE
fix(scripts): correct tmux pane selection syntax in preview script

### DIFF
--- a/scripts/.preview
+++ b/scripts/.preview
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-[ "$1" != '[cancel]' ] && [ "$1" != '[current]' ] && echo $1 | sed 's/: .*$//' | xargs -I{} tmux capture-pane -ep -t {}:
+[ "$1" != '[cancel]' ] && [ "$1" != '[current]' ] && echo $1 | sed 's/: .*$//' | xargs -I{} tmux capture-pane -ep -t {}


### PR DESCRIPTION
Trailing `:` caused [#95](https://github.com/sainnhe/tmux-fzf/issues/95).
This change fixes the issue.