### PR TITLE
Fix window preview regex to preserve session:window format

### DIFF
--- a/scripts/.preview
+++ b/scripts/.preview
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-[ "$1" != '[cancel]' ] && [ "$1" != '[current]' ] && echo $1 | sed 's/: .*$//' | xargs -I{} tmux capture-pane -ep -t {}:
+[ "$1" != '[cancel]' ] && [ "$1" != '[current]' ] && echo $1 | sed 's/: [^:]*$//' | xargs -I{} tmux capture-pane -ep -t {}


### PR DESCRIPTION
## Problem
  When using tmux-fzf window selection with preview enabled, users encounter a 'can't find window #' error. This happens because the current regex pattern incorrectly parses the window target format.

 ## Root Cause
The original regex \`s/: .*$/\` removes everything after the first colon and space, extracting only the session name (e.g., 'session' from 'session:0: window_name'). However, tmux commands require the full 'session:window' format to properly identify windows.

## Solution
Changed the regex to \`s/: [^:]*$/\` which removes only the last colon-separated segment (window name and details), preserving the 'session:window' format that tmux expects.

