### PR TITLE
feat: add unified command palette for flat search across sessions/windows/panes

### DIFF
--- a/scripts/.utils
+++ b/scripts/.utils
@@ -38,7 +38,7 @@ select_swap_target() {
 # Usage: break_pane_to_window "$target"
 break_pane_to_window() {
     local target="$1"
-    local cur_ses=$(tmux display-message -p | sed -e 's/^.//' -e 's/].*//')
+    local cur_ses=$(tmux display-message -p | sed -e 's/^\[//' -e 's/\].*//')
     local last_win_num=$(tmux list-windows | sort -nr | head -1 | sed 's/:.*//')
     local next_win=$((last_win_num + 1))
     tmux break-pane -s "$target" -t "$cur_ses":"$next_win"
@@ -47,7 +47,7 @@ break_pane_to_window() {
 # Get current session name
 # Usage: ses=$(get_current_session)
 get_current_session() {
-    tmux display-message -p | sed -e 's/^.//' -e 's/].*//'
+    tmux display-message -p | sed -e 's/^\[//' -e 's/\].*//'
 }
 
 # Select source window from other sessions (for link/move)

--- a/scripts/.utils
+++ b/scripts/.utils
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Common utility functions for tmux-fzf scripts
+
+# Prompt for name input via tmux split-window
+# Usage: name=$(prompt_name "Session Name") || exit
+prompt_name() {
+    local prompt="$1"
+    local fifo=$(mktemp -u "/tmp/tmux_fzf_name_XXXXXX")
+    mkfifo "$fifo" || return 1
+    # Use timeout to prevent hanging if user closes window without input
+    tmux split-window -v -l 30% -b "bash -c 'printf \"%s: \" \"$prompt\" && read name && echo \"\$name\" > $fifo'" &
+    local result
+    # Read with timeout (30 seconds)
+    if command -v timeout &>/dev/null; then
+        result=$(timeout 30 cat "$fifo" 2>/dev/null)
+    else
+        result=$(cat "$fifo")
+    fi
+    rm -f "$fifo"
+    [[ -z "$result" ]] && return 1
+    echo "$result"
+}
+
+# Select swap target from list (excludes current target)
+# Usage: target=$(select_swap_target "$items" "$exclude" "header text") || exit
+select_swap_target() {
+    local items="$1"
+    local exclude="$2"
+    local header="$3"
+    local filtered=$(echo "$items" | grep -v "^$exclude")
+    FZF_DEFAULT_OPTS="$FZF_DEFAULT_OPTS --header='$header'"
+    local selected=$(printf "%s\n[cancel]" "$filtered" | eval "$TMUX_FZF_BIN $TMUX_FZF_OPTIONS $TMUX_FZF_PREVIEW_OPTIONS")
+    [[ "$selected" == "[cancel]" || -z "$selected" ]] && return 1
+    echo "$selected" | sed 's/: .*//'
+}
+
+# Break pane to new window
+# Usage: break_pane_to_window "$target"
+break_pane_to_window() {
+    local target="$1"
+    local cur_ses=$(tmux display-message -p | sed -e 's/^.//' -e 's/].*//')
+    local last_win_num=$(tmux list-windows | sort -nr | head -1 | sed 's/:.*//')
+    local next_win=$((last_win_num + 1))
+    tmux break-pane -s "$target" -t "$cur_ses":"$next_win"
+}
+
+# Get current session name
+# Usage: ses=$(get_current_session)
+get_current_session() {
+    tmux display-message -p | sed -e 's/^.//' -e 's/].*//'
+}
+
+# Select source window from other sessions (for link/move)
+# Usage: src_win=$(select_source_window "$windows") || exit
+# Returns: selected window target (session:index)
+select_source_window() {
+    local windows="$1"
+    local cur_ses=$(get_current_session)
+    local filtered=$(echo "$windows" | grep -v "^$cur_ses")
+    FZF_DEFAULT_OPTS="$FZF_DEFAULT_OPTS --header='Select source window.'"
+    local selected=$(printf "%s\n[cancel]" "$filtered" | eval "$TMUX_FZF_BIN $TMUX_FZF_OPTIONS $TMUX_FZF_PREVIEW_OPTIONS")
+    [[ "$selected" == "[cancel]" || -z "$selected" ]] && return 1
+    echo "$selected" | sed 's/: .*//'
+}

--- a/scripts/pane.sh
+++ b/scripts/pane.sh
@@ -2,6 +2,7 @@
 
 CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$CURRENT_DIR/.envs"
+source "$CURRENT_DIR/.utils"
 
 current_pane_origin=$(tmux display-message -p '#S:#{window_index}.#{pane_index}: #{window_name}')
 current_pane=$(tmux display-message -p '#S:#{window_index}.#{pane_index}')
@@ -14,12 +15,14 @@ fi
 
 FZF_DEFAULT_OPTS="$FZF_DEFAULT_OPTS --header='Select an action.'"
 if [[ -z "$1" ]]; then
-    action=$(printf "switch\nbreak\njoin\nswap\nlayout\nkill\nresize\n[cancel]" | eval "$TMUX_FZF_BIN $TMUX_FZF_OPTIONS")
+    action=$(printf "switch\nzoom\nbreak\njoin\nswap\nlayout\nkill\nresize\n[cancel]" | eval "$TMUX_FZF_BIN $TMUX_FZF_OPTIONS")
 else
     action="$1"
 fi
 
 [[ "$action" == "[cancel]" || -z "$action" ]] && exit
+
+# layout and resize have sub-menus, no target needed
 if [[ "$action" == "layout" ]]; then
     FZF_DEFAULT_OPTS="$FZF_DEFAULT_OPTS --header='Select a layout.'"
     target_origin=$(printf "even-horizontal\neven-vertical\nmain-horizontal\nmain-vertical\ntiled\n[cancel]" | eval "$TMUX_FZF_BIN $TMUX_FZF_OPTIONS")
@@ -48,7 +51,33 @@ elif [[ "$action" == "resize" ]]; then
             tmux resize-pane -D "$size"
         fi
     fi
+# Support $2 as pre-selected target (for unified.sh integration)
+elif [[ -n "$2" ]]; then
+    # Handle [current] special case
+    if [[ "$2" == "[current]" ]]; then
+        target="$current_pane"
+    else
+        target="$2"
+    fi
+    # Execute based on action with pre-selected target
+    if [[ "$action" == "switch" ]]; then
+        echo "$target" | sed -E 's/:.*//g' | xargs -I{} tmux switch-client -t {}
+        echo "$target" | sed -E 's/\..*//g' | xargs -I{} tmux select-window -t {}
+        tmux select-pane -t "$target"
+    elif [[ "$action" == "kill" ]]; then
+        tmux kill-pane -t "$target"
+    elif [[ "$action" == "swap" ]]; then
+        target_swap=$(select_swap_target "$panes" "$target" "Select another target pane.") || exit
+        tmux swap-pane -s "$target" -t "$target_swap"
+    elif [[ "$action" == "join" ]]; then
+        tmux move-pane -s "$target"
+    elif [[ "$action" == "break" ]]; then
+        break_pane_to_window "$target"
+    elif [[ "$action" == "zoom" ]]; then
+        tmux resize-pane -Z -t "$target"
+    fi
 else
+    # Original fzf selection logic
     if [[ "$action" == "join" || "$action" == "kill" ]]; then
         FZF_DEFAULT_OPTS="$FZF_DEFAULT_OPTS --header='Select target pane(s). Press TAB to mark multiple items.'"
     else
@@ -71,19 +100,14 @@ else
         echo "$target" | xargs -I{} tmux select-pane -t {}
     elif [[ "$action" == "kill" ]]; then
         echo "$target" | sort -r | xargs -I{} tmux kill-pane -t {}
+    elif [[ "$action" == "zoom" ]]; then
+        tmux resize-pane -Z -t "$target"
     elif [[ "$action" == "swap" ]]; then
-        panes=$(echo "$panes" | grep -v "^$target")
-        FZF_DEFAULT_OPTS="$FZF_DEFAULT_OPTS --header='Select another target pane.'"
-        target_swap_origin=$(printf "%s\n[cancel]" "$panes" | eval "$TMUX_FZF_BIN $TMUX_FZF_OPTIONS $TMUX_FZF_PREVIEW_OPTIONS")
-        [[ "$target_swap_origin" == "[cancel]" || -z "$target_swap_origin" ]] && exit
-        target_swap=$(echo "$target_swap_origin" | sed 's/: .*//')
+        target_swap=$(select_swap_target "$panes" "$target" "Select another target pane.") || exit
         tmux swap-pane -s "$target" -t "$target_swap"
     elif [[ "$action" == "join" ]]; then
         echo "$target" | sort -r | xargs -I{} tmux move-pane -s {}
     elif [[ "$action" == "break" ]]; then
-        cur_ses=$(tmux display-message -p | sed -e 's/^.//' -e 's/].*//')
-        last_win_num=$(tmux list-windows | sort -nr | head -1 | sed 's/:.*//')
-        ((last_win_num_after = last_win_num + 1))
-        tmux break-pane -s "$target" -t "$cur_ses":"$last_win_num_after"
+        break_pane_to_window "$target"
     fi
 fi

--- a/scripts/pane.sh
+++ b/scripts/pane.sh
@@ -63,7 +63,7 @@ elif [[ -n "$2" ]]; then
     if [[ "$action" == "switch" ]]; then
         echo "$target" | sed -E 's/:.*//g' | xargs -I{} tmux switch-client -t {}
         echo "$target" | sed -E 's/\..*//g' | xargs -I{} tmux select-window -t {}
-        tmux select-pane -t "$target"
+        echo "$target" | xargs -I{} tmux select-pane -t {}
     elif [[ "$action" == "kill" ]]; then
         tmux kill-pane -t "$target"
     elif [[ "$action" == "swap" ]]; then

--- a/scripts/session.sh
+++ b/scripts/session.sh
@@ -2,6 +2,7 @@
 
 CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$CURRENT_DIR/.envs"
+source "$CURRENT_DIR/.utils"
 
 if [[ -z "$TMUX_FZF_SESSION_FORMAT" ]]; then
     sessions=$(tmux list-sessions)
@@ -9,8 +10,9 @@ else
     sessions=$(tmux list-sessions -F "#S: $TMUX_FZF_SESSION_FORMAT")
 fi
 
+# Always initialize current_session (needed for [current] support)
+current_session=$(tmux display-message -p | sed -e 's/^\[//' -e 's/\].*//')
 if [[ -z "$TMUX_FZF_SWITCH_CURRENT" ]]; then
-    current_session=$(tmux display-message -p | sed -e 's/^\[//' -e 's/\].*//')
     sessions=$(echo "$sessions" | grep -v "^$current_session: ")
 fi
 
@@ -22,40 +24,50 @@ else
 fi
 
 [[ "$action" == "[cancel]" || -z "$action" ]] && exit
-if [[ "$action" != "detach" ]]; then
-    if [[ "$action" == "kill" ]]; then
-        FZF_DEFAULT_OPTS="$FZF_DEFAULT_OPTS --header='Select target session(s). Press TAB to mark multiple items.'"
+
+# Support $2 as pre-selected target (for unified.sh integration)
+if [[ -n "$2" ]]; then
+    # Handle [current] special case
+    if [[ "$2" == "[current]" ]]; then
+        target="$current_session"
     else
-        FZF_DEFAULT_OPTS="$FZF_DEFAULT_OPTS --header='Select target session.'"
+        target="$2"
     fi
-    if [[ "$action" == "switch" ]]; then
-        target_origin=$(printf "%s\n[cancel]" "$sessions" | eval "$TMUX_FZF_BIN $TMUX_FZF_OPTIONS $TMUX_FZF_PREVIEW_SESSION_OPTIONS")
-    elif [[ "$action" != "new" ]]; then
+    # For rename action, still need to prompt for new name
+    if [[ "$action" == "rename" ]]; then
+        session_name=$(prompt_name "Session Name") || exit
+    fi
+else
+    # Original fzf selection logic
+    if [[ "$action" != "detach" ]]; then
+        if [[ "$action" == "kill" ]]; then
+            FZF_DEFAULT_OPTS="$FZF_DEFAULT_OPTS --header='Select target session(s). Press TAB to mark multiple items.'"
+        else
+            FZF_DEFAULT_OPTS="$FZF_DEFAULT_OPTS --header='Select target session.'"
+        fi
+        if [[ "$action" == "switch" ]]; then
+            target_origin=$(printf "%s\n[cancel]" "$sessions" | eval "$TMUX_FZF_BIN $TMUX_FZF_OPTIONS $TMUX_FZF_PREVIEW_SESSION_OPTIONS")
+        elif [[ "$action" != "new" ]]; then
+            target_origin=$(printf "[current]\n%s\n[cancel]" "$sessions" | eval "$TMUX_FZF_BIN $TMUX_FZF_OPTIONS $TMUX_FZF_PREVIEW_SESSION_OPTIONS")
+            target_origin=$(echo "$target_origin" | sed -E "s/\[current\]/$current_session:/")
+        fi
+        if [[ "$action" == "new" || "$action" == "rename" ]]; then
+            session_name=$(prompt_name "Session Name") || exit
+            if [[ "$action" == "new" ]]; then
+                tmux new-session -d -s "$session_name" && tmux switch-client -t "$session_name"
+                exit
+            fi
+        fi
+    else
+        tmux_attached_sessions=$(tmux list-sessions | grep 'attached' | grep -o '^[[:alpha:][:digit:]_-]*:' | sed 's/.$//g')
+        sessions=$(echo "$sessions" | grep "^$tmux_attached_sessions")
+        FZF_DEFAULT_OPTS="$FZF_DEFAULT_OPTS --header='Select target session(s). Press TAB to mark multiple items.'"
         target_origin=$(printf "[current]\n%s\n[cancel]" "$sessions" | eval "$TMUX_FZF_BIN $TMUX_FZF_OPTIONS $TMUX_FZF_PREVIEW_SESSION_OPTIONS")
         target_origin=$(echo "$target_origin" | sed -E "s/\[current\]/$current_session:/")
     fi
-    if [[ "$action" == "new" || "$action" == "rename" ]]; then
-        mkfifo /tmp/tmux_fzf_session_name
-        tmux split-window -v -l 30% -b "bash -c 'printf \"Session Name: \" && read session_name && echo \"\$session_name\" > /tmp/tmux_fzf_session_name'" &
-        session_name=$(cat /tmp/tmux_fzf_session_name)
-        rm /tmp/tmux_fzf_session_name
-        if [ -z "$session_name" ]; then
-            exit
-        fi
-        if [[ "$action" == "new" ]]; then
-            tmux new-session -d -s "$session_name" && tmux switch-client -t "$session_name"
-            exit
-        fi
-    fi
-else
-    tmux_attached_sessions=$(tmux list-sessions | grep 'attached' | grep -o '^[[:alpha:][:digit:]_-]*:' | sed 's/.$//g')
-    sessions=$(echo "$sessions" | grep "^$tmux_attached_sessions")
-    FZF_DEFAULT_OPTS="$FZF_DEFAULT_OPTS --header='Select target session(s). Press TAB to mark multiple items.'"
-    target_origin=$(printf "[current]\n%s\n[cancel]" "$sessions" | eval "$TMUX_FZF_BIN $TMUX_FZF_OPTIONS $TMUX_FZF_PREVIEW_SESSION_OPTIONS")
-    target_origin=$(echo "$target_origin" | sed -E "s/\[current\]/$current_session:/")
+    [[ "$target_origin" == "[cancel]" || -z "$target_origin" ]] && exit
+    target=$(echo "$target_origin" | sed -e 's/:.*$//')
 fi
-[[ "$target_origin" == "[cancel]" || -z "$target_origin" ]] && exit
-target=$(echo "$target_origin" | sed -e 's/:.*$//')
 if [[ "$action" == "switch" ]]; then
     tmux switch-client -t "$target"
 elif [[ "$action" == "detach" ]]; then

--- a/scripts/unified.sh
+++ b/scripts/unified.sh
@@ -13,49 +13,49 @@ current_pane=$(tmux display-message -p '#S:#{window_index}.#{pane_index}')
 generate_candidates() {
     # ========== Session commands ==========
     # new session (no target)
-    echo "[ses] new  # create new session"
+    echo "[S] new  # create new session"
 
     # session × actions
     tmux list-sessions -F '#{session_name}|#{session_windows}|#{session_attached}' 2>/dev/null | while IFS='|' read -r name wins attached; do
         local mark=""
         [[ "$attached" == "1" ]] && mark="*"
         # Direct execution
-        echo "[ses] switch $name  # $mark ($wins win)"
-        echo "[ses] kill $name  # $mark"
-        echo "[ses] detach $name  # $mark"
+        echo "[S] switch $name  # $mark ($wins win)"
+        echo "[S] kill $name  # $mark"
+        echo "[S] detach $name  # $mark"
         # Interactive (rename needs input)
-        echo "[ses] rename $name  # $mark -> input new name"
+        echo "[S] rename $name  # $mark -> input new name"
     done
 
     # [current] session
-    echo "[ses] rename [current]  # -> input new name"
+    echo "[S] rename [current]  # -> input new name"
 
     # ========== Window commands ==========
     # new window (no target)
-    echo "[win] new  # create new window"
-    echo "[win] split-h  # split horizontal"
-    echo "[win] split-v  # split vertical"
+    echo "[W] new  # create new window"
+    echo "[W] split-h  # split horizontal"
+    echo "[W] split-v  # split vertical"
 
     # window × actions
     tmux list-windows -a -F '#{session_name}:#{window_index}|#{window_name}|#{window_active}' 2>/dev/null | while IFS='|' read -r target wname active; do
         local mark=""
         [[ "$active" == "1" ]] && mark="*"
         # Direct execution
-        echo "[win] switch $target  # $wname $mark"
-        echo "[win] kill $target  # $wname"
+        echo "[W] switch $target  # $wname $mark"
+        echo "[W] kill $target  # $wname"
         # Interactive
-        echo "[win] rename $target  # $wname -> input new name"
-        echo "[win] swap $target  # $wname -> select another"
+        echo "[W] rename $target  # $wname -> input new name"
+        echo "[W] swap $target  # $wname -> select another"
     done
 
     # [current] window
-    echo "[win] rename [current]  # -> input new name"
-    echo "[win] kill [current]"
-    echo "[win] swap [current]  # -> select another"
+    echo "[W] rename [current]  # -> input new name"
+    echo "[W] kill [current]"
+    echo "[W] swap [current]  # -> select another"
 
     # link/move (original fzf flow)
-    echo "[win] link  # -> select source window"
-    echo "[win] move  # -> select source window"
+    echo "[W] link  # -> select source window"
+    echo "[W] move  # -> select source window"
 
     # ========== Pane commands ==========
     # pane × actions
@@ -63,24 +63,24 @@ generate_candidates() {
         local mark=""
         [[ "$active" == "1" ]] && mark="*"
         # Direct execution
-        echo "[pane] switch $target  # $pcmd $mark"
-        echo "[pane] kill $target  # $pcmd"
-        echo "[pane] zoom $target  # $pcmd"
-        echo "[pane] break $target  # $pcmd -> new window"
+        echo "[P] switch $target  # $pcmd $mark"
+        echo "[P] kill $target  # $pcmd"
+        echo "[P] zoom $target  # $pcmd"
+        echo "[P] break $target  # $pcmd -> new window"
         # Interactive
-        echo "[pane] swap $target  # $pcmd -> select another"
-        echo "[pane] join $target  # $pcmd -> move here"
+        echo "[P] swap $target  # $pcmd -> select another"
+        echo "[P] join $target  # $pcmd -> move here"
     done
 
     # [current] pane
-    echo "[pane] zoom [current]"
-    echo "[pane] kill [current]"
-    echo "[pane] break [current]  # -> new window"
-    echo "[pane] swap [current]  # -> select another"
+    echo "[P] zoom [current]"
+    echo "[P] kill [current]"
+    echo "[P] break [current]  # -> new window"
+    echo "[P] swap [current]  # -> select another"
 
     # layout/resize (sub-menu, no target)
-    echo "[pane] layout  # -> select layout"
-    echo "[pane] resize  # -> select direction & size"
+    echo "[P] layout  # -> select layout"
+    echo "[P] resize  # -> select direction & size"
 }
 
 # Create preview script
@@ -113,7 +113,7 @@ echo "$preview_script" > "$preview_file"
 chmod +x "$preview_file"
 
 # Set header
-FZF_DEFAULT_OPTS="$FZF_DEFAULT_OPTS --header='Tmux Command Palette  [ses] [win] [pane]'"
+FZF_DEFAULT_OPTS="$FZF_DEFAULT_OPTS --header='Tmux Command Palette  [S]ession [W]indow [P]ane'"
 
 # Determine preview options
 if [[ "$TMUX_FZF_PREVIEW" != "0" ]]; then
@@ -139,7 +139,7 @@ target=$(echo "$rest" | awk '{print $2}')
 
 # Dispatch based on type and action
 case "$type" in
-    "[ses]")
+    "[S]")
         case "$action" in
             switch)
                 tmux switch-client -t "$target"
@@ -159,7 +159,7 @@ case "$type" in
                 ;;
         esac
         ;;
-    "[win]")
+    "[W]")
         case "$action" in
             switch)
                 # Switch to session first, then window
@@ -197,7 +197,7 @@ case "$type" in
                 ;;
         esac
         ;;
-    "[pane]")
+    "[P]")
         case "$action" in
             switch)
                 session=$(echo "$target" | sed -E 's/:.*//g')

--- a/scripts/unified.sh
+++ b/scripts/unified.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+# Unified Command Palette - flat search for all tmux commands
+# Usage: bind-key P run-shell -b "path/to/unified.sh"
+
+CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$CURRENT_DIR/.envs"
+
+# Get current context
+current_session=$(tmux display-message -p '#{session_name}')
+current_window=$(tmux display-message -p '#S:#I')
+current_pane=$(tmux display-message -p '#S:#{window_index}.#{pane_index}')
+
+generate_candidates() {
+    # ========== Session commands ==========
+    # new session (no target)
+    echo "[ses] new  # create new session"
+
+    # session × actions
+    tmux list-sessions -F '#{session_name}|#{session_windows}|#{session_attached}' 2>/dev/null | while IFS='|' read -r name wins attached; do
+        local mark=""
+        [[ "$attached" == "1" ]] && mark="*"
+        # Direct execution
+        echo "[ses] switch $name  # $mark ($wins win)"
+        echo "[ses] kill $name  # $mark"
+        echo "[ses] detach $name  # $mark"
+        # Interactive (rename needs input)
+        echo "[ses] rename $name  # $mark -> input new name"
+    done
+
+    # [current] session
+    echo "[ses] rename [current]  # -> input new name"
+
+    # ========== Window commands ==========
+    # new window (no target)
+    echo "[win] new  # create new window"
+    echo "[win] split-h  # split horizontal"
+    echo "[win] split-v  # split vertical"
+
+    # window × actions
+    tmux list-windows -a -F '#{session_name}:#{window_index}|#{window_name}|#{window_active}' 2>/dev/null | while IFS='|' read -r target wname active; do
+        local mark=""
+        [[ "$active" == "1" ]] && mark="*"
+        # Direct execution
+        echo "[win] switch $target  # $wname $mark"
+        echo "[win] kill $target  # $wname"
+        # Interactive
+        echo "[win] rename $target  # $wname -> input new name"
+        echo "[win] swap $target  # $wname -> select another"
+    done
+
+    # [current] window
+    echo "[win] rename [current]  # -> input new name"
+    echo "[win] kill [current]"
+    echo "[win] swap [current]  # -> select another"
+
+    # link/move (original fzf flow)
+    echo "[win] link  # -> select source window"
+    echo "[win] move  # -> select source window"
+
+    # ========== Pane commands ==========
+    # pane × actions
+    tmux list-panes -a -F '#{session_name}:#{window_index}.#{pane_index}|#{pane_current_command}|#{pane_active}' 2>/dev/null | while IFS='|' read -r target pcmd active; do
+        local mark=""
+        [[ "$active" == "1" ]] && mark="*"
+        # Direct execution
+        echo "[pane] switch $target  # $pcmd $mark"
+        echo "[pane] kill $target  # $pcmd"
+        echo "[pane] zoom $target  # $pcmd"
+        echo "[pane] break $target  # $pcmd -> new window"
+        # Interactive
+        echo "[pane] swap $target  # $pcmd -> select another"
+        echo "[pane] join $target  # $pcmd -> move here"
+    done
+
+    # [current] pane
+    echo "[pane] zoom [current]"
+    echo "[pane] kill [current]"
+    echo "[pane] break [current]  # -> new window"
+    echo "[pane] swap [current]  # -> select another"
+
+    # layout/resize (sub-menu, no target)
+    echo "[pane] layout  # -> select layout"
+    echo "[pane] resize  # -> select direction & size"
+}
+
+# Create preview script
+preview_script=$(cat << 'PREVIEW_SCRIPT'
+#!/usr/bin/env bash
+line="$1"
+# Extract target (word after action)
+target=$(echo "$line" | sed 's/^\[[^]]*\] [^ ]* //' | sed 's/  #.*//' | awk '{print $1}')
+if [[ -n "$target" && "$target" != "#" ]]; then
+    if [[ "$target" == "[current]" ]]; then
+        tmux capture-pane -ep 2>/dev/null
+    elif [[ "$target" == *"."* ]]; then
+        # Pane target (session:window.pane)
+        tmux capture-pane -ep -t "$target" 2>/dev/null
+    elif [[ "$target" == *":"* ]]; then
+        # Window target (session:window)
+        tmux capture-pane -ep -t "$target" 2>/dev/null
+    else
+        # Session target
+        tmux capture-pane -ep -t "$target:" 2>/dev/null
+    fi
+else
+    echo "Command: $line"
+fi
+PREVIEW_SCRIPT
+)
+
+preview_file=$(mktemp "/tmp/tmux-fzf-unified-preview-XXXXXX.sh")
+echo "$preview_script" > "$preview_file"
+chmod +x "$preview_file"
+
+# Set header
+FZF_DEFAULT_OPTS="$FZF_DEFAULT_OPTS --header='Tmux Command Palette  [ses] [win] [pane]'"
+
+# Determine preview options
+if [[ "$TMUX_FZF_PREVIEW" != "0" ]]; then
+    preview_opts="--preview='$preview_file {}'"
+else
+    preview_opts=""
+fi
+
+# Run fzf and get selection
+selected=$(generate_candidates | eval "$TMUX_FZF_BIN $TMUX_FZF_OPTIONS $preview_opts")
+
+# Cleanup
+rm -f "$preview_file"
+
+# Exit if nothing selected
+[[ -z "$selected" ]] && exit 0
+
+# Parse selection: [type] action target  # comment
+type=$(echo "$selected" | grep -oE '^\[[^]]+\]')
+rest=$(echo "$selected" | sed 's/^\[[^]]*\] //' | sed 's/  #.*//')
+action=$(echo "$rest" | awk '{print $1}')
+target=$(echo "$rest" | awk '{print $2}')
+
+# Dispatch based on type and action
+case "$type" in
+    "[ses]")
+        case "$action" in
+            switch)
+                tmux switch-client -t "$target"
+                ;;
+            kill)
+                tmux kill-session -t "$target"
+                ;;
+            detach)
+                tmux detach -s "$target"
+                ;;
+            rename)
+                # Call original script with action and target
+                "$CURRENT_DIR/session.sh" rename "$target"
+                ;;
+            new)
+                "$CURRENT_DIR/session.sh" new
+                ;;
+        esac
+        ;;
+    "[win]")
+        case "$action" in
+            switch)
+                # Switch to session first, then window
+                session=$(echo "$target" | sed 's/:.*//')
+                tmux switch-client -t "$session"
+                tmux select-window -t "$target"
+                ;;
+            kill)
+                if [[ "$target" == "[current]" ]]; then
+                    tmux kill-window
+                else
+                    tmux unlink-window -k -t "$target"
+                fi
+                ;;
+            rename)
+                "$CURRENT_DIR/window.sh" rename "$target"
+                ;;
+            swap)
+                "$CURRENT_DIR/window.sh" swap "$target"
+                ;;
+            new)
+                tmux new-window
+                ;;
+            split-h)
+                tmux split-window -h
+                ;;
+            split-v)
+                tmux split-window -v
+                ;;
+            link)
+                "$CURRENT_DIR/window.sh" link
+                ;;
+            move)
+                "$CURRENT_DIR/window.sh" move
+                ;;
+        esac
+        ;;
+    "[pane]")
+        case "$action" in
+            switch)
+                session=$(echo "$target" | sed -E 's/:.*//g')
+                window=$(echo "$target" | sed -E 's/\..*//g')
+                tmux switch-client -t "$session"
+                tmux select-window -t "$window"
+                tmux select-pane -t "$target"
+                ;;
+            kill)
+                if [[ "$target" == "[current]" ]]; then
+                    tmux kill-pane
+                else
+                    tmux kill-pane -t "$target"
+                fi
+                ;;
+            zoom)
+                if [[ "$target" == "[current]" ]]; then
+                    tmux resize-pane -Z
+                else
+                    tmux resize-pane -Z -t "$target"
+                fi
+                ;;
+            break)
+                "$CURRENT_DIR/pane.sh" break "$target"
+                ;;
+            swap)
+                "$CURRENT_DIR/pane.sh" swap "$target"
+                ;;
+            join)
+                "$CURRENT_DIR/pane.sh" join "$target"
+                ;;
+            layout)
+                "$CURRENT_DIR/pane.sh" layout
+                ;;
+            resize)
+                "$CURRENT_DIR/pane.sh" resize
+                ;;
+        esac
+        ;;
+esac

--- a/scripts/window.sh
+++ b/scripts/window.sh
@@ -2,6 +2,7 @@
 
 CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$CURRENT_DIR/.envs"
+source "$CURRENT_DIR/.utils"
 
 current_window_origin=$(tmux display-message -p '#S:#I: #{window_name}')
 current_window=$(tmux display-message -p '#S:#I:')
@@ -27,61 +28,64 @@ else
 fi
 
 [[ "$action" == "[cancel]" || -z "$action" ]] && exit
-if [[ "$action" == "link" ]]; then
-    cur_ses=$(tmux display-message -p | sed -e 's/^.//' -e 's/].*//')
-    last_win_num=$(tmux list-windows | sort -r | sed '2,$d' | sed 's/:.*//')
-    windows=$(echo "$windows" | grep -v "^$cur_ses")
-    FZF_DEFAULT_OPTS="$FZF_DEFAULT_OPTS --header='Select source window.'"
-    src_win_origin=$(printf "%s\n[cancel]" "$windows" | eval "$TMUX_FZF_BIN $TMUX_FZF_OPTIONS $TMUX_FZF_PREVIEW_OPTIONS")
-    [[ "$src_win_origin" == "[cancel]" || -z "$src_win_origin" ]] && exit
-    src_win=$(echo "$src_win_origin" | sed 's/: .*//')
-    tmux link-window -a -s "$src_win" -t "$cur_ses"
-elif [[ "$action" == "move" ]]; then
-    cur_ses=$(tmux display-message -p | sed -e 's/^.//' -e 's/].*//')
-    last_win_num=$(tmux list-windows | sort -r | sed '2,$d' | sed 's/:.*//')
-    windows=$(echo "$windows" | grep -v "^$cur_ses")
-    FZF_DEFAULT_OPTS="$FZF_DEFAULT_OPTS --header='Select source window.'"
-    src_win_origin=$(printf "%s\n[cancel]" "$windows" | eval "$TMUX_FZF_BIN $TMUX_FZF_OPTIONS $TMUX_FZF_PREVIEW_OPTIONS")
-    [[ "$src_win_origin" == "[cancel]" || -z "$src_win_origin" ]] && exit
-    src_win=$(echo "$src_win_origin" | sed 's/: .*//')
-    tmux move-window -a -s "$src_win" -t "$cur_ses"
-else
-    if [[ "$action" == "kill" ]]; then
-        FZF_DEFAULT_OPTS="$FZF_DEFAULT_OPTS --header='Select target window(s). Press TAB to mark multiple items.'"
+
+# Support $2 as pre-selected target (for unified.sh integration)
+if [[ -n "$2" ]]; then
+    # Handle [current] special case
+    if [[ "$2" == "[current]" ]]; then
+        target=$(echo "$current_window" | sed 's/:$//')
     else
-        FZF_DEFAULT_OPTS="$FZF_DEFAULT_OPTS --header='Select target window.'"
+        target="$2"
     fi
-    if [[ "$action" != "switch" ]]; then
-        target_origin=$(printf "[current]\n%s\n[cancel]" "$windows" | eval "$TMUX_FZF_BIN $TMUX_FZF_OPTIONS $TMUX_FZF_PREVIEW_OPTIONS")
-        target_origin=${target_origin/\[current\]/$current_window_origin}
-    else
-        if [[ -z "$TMUX_FZF_SWITCH_CURRENT" ]]; then
-            windows=$(echo "$windows" | grep -v "^$current_window")
-        fi
-        target_origin=$(printf "%s\n[cancel]" "$windows" | eval "$TMUX_FZF_BIN $TMUX_FZF_OPTIONS $TMUX_FZF_PREVIEW_OPTIONS")
-    fi
-    [[ "$target_origin" == "[cancel]" || -z "$target_origin" ]] && exit
-    target=$(echo "$target_origin" | sed 's/: .*//')
+    # Execute based on action with pre-selected target
     if [[ "$action" == "kill" ]]; then
-        echo "$target" | sort -r | xargs -I{} tmux unlink-window -k -t {}
+        tmux unlink-window -k -t "$target"
     elif [[ "$action" == "rename" ]]; then
-        mkfifo /tmp/tmux_fzf_window_name
-        tmux split-window -v -l 30% -b "bash -c 'printf \"Window Name: \" && read window_name && echo \"\$window_name\" > /tmp/tmux_fzf_window_name'" &
-        window_name=$(cat /tmp/tmux_fzf_window_name)
-        rm /tmp/tmux_fzf_window_name
-        if [ -z "$window_name" ]; then
-            exit
-        fi
+        window_name=$(prompt_name "Window Name") || exit
         tmux rename-window -t "$target" "$window_name"
     elif [[ "$action" == "swap" ]]; then
-        windows=$(echo "$windows" | grep -v "^$target")
-        FZF_DEFAULT_OPTS="$FZF_DEFAULT_OPTS --header='Select another target window.'"
-        target_swap_origin=$(printf "%s\n[cancel]" "$windows" | eval "$TMUX_FZF_BIN $TMUX_FZF_OPTIONS $TMUX_FZF_PREVIEW_OPTIONS")
-        [[ "$target_swap_origin" == "[cancel]" || -z "$target_swap_origin" ]] && exit
-        target_swap=$(echo "$target_swap_origin" | sed 's/: .*//')
+        target_swap=$(select_swap_target "$windows" "$target" "Select another target window.") || exit
         tmux swap-window -s "$target" -t "$target_swap"
     elif [[ "$action" == "switch" ]]; then
         echo "$target" | sed 's/:.*//g' | xargs -I{} tmux switch-client -t {}
-        echo "$target" | xargs -I{} tmux select-window -t {}
+        tmux select-window -t "$target"
+    fi
+else
+    # Original fzf selection logic
+    if [[ "$action" == "link" ]]; then
+        src_win=$(select_source_window "$windows") || exit
+        tmux link-window -a -s "$src_win" -t "$(get_current_session)"
+    elif [[ "$action" == "move" ]]; then
+        src_win=$(select_source_window "$windows") || exit
+        tmux move-window -a -s "$src_win" -t "$(get_current_session)"
+    else
+        if [[ "$action" == "kill" ]]; then
+            FZF_DEFAULT_OPTS="$FZF_DEFAULT_OPTS --header='Select target window(s). Press TAB to mark multiple items.'"
+        else
+            FZF_DEFAULT_OPTS="$FZF_DEFAULT_OPTS --header='Select target window.'"
+        fi
+        if [[ "$action" != "switch" ]]; then
+            target_origin=$(printf "[current]\n%s\n[cancel]" "$windows" | eval "$TMUX_FZF_BIN $TMUX_FZF_OPTIONS $TMUX_FZF_PREVIEW_OPTIONS")
+            target_origin=${target_origin/\[current\]/$current_window_origin}
+        else
+            if [[ -z "$TMUX_FZF_SWITCH_CURRENT" ]]; then
+                windows=$(echo "$windows" | grep -v "^$current_window")
+            fi
+            target_origin=$(printf "%s\n[cancel]" "$windows" | eval "$TMUX_FZF_BIN $TMUX_FZF_OPTIONS $TMUX_FZF_PREVIEW_OPTIONS")
+        fi
+        [[ "$target_origin" == "[cancel]" || -z "$target_origin" ]] && exit
+        target=$(echo "$target_origin" | sed 's/: .*//')
+        if [[ "$action" == "kill" ]]; then
+            echo "$target" | sort -r | xargs -I{} tmux unlink-window -k -t {}
+        elif [[ "$action" == "rename" ]]; then
+            window_name=$(prompt_name "Window Name") || exit
+            tmux rename-window -t "$target" "$window_name"
+        elif [[ "$action" == "swap" ]]; then
+            target_swap=$(select_swap_target "$windows" "$target" "Select another target window.") || exit
+            tmux swap-window -s "$target" -t "$target_swap"
+        elif [[ "$action" == "switch" ]]; then
+            echo "$target" | sed 's/:.*//g' | xargs -I{} tmux switch-client -t {}
+            echo "$target" | xargs -I{} tmux select-window -t {}
+        fi
     fi
 fi

--- a/scripts/window.sh
+++ b/scripts/window.sh
@@ -48,7 +48,7 @@ if [[ -n "$2" ]]; then
         tmux swap-window -s "$target" -t "$target_swap"
     elif [[ "$action" == "switch" ]]; then
         echo "$target" | sed 's/:.*//g' | xargs -I{} tmux switch-client -t {}
-        tmux select-window -t "$target"
+        echo "$target" | xargs -I{} tmux select-window -t {}
     fi
 else
     # Original fzf selection logic


### PR DESCRIPTION
## Summary

Add a unified command palette that provides VS Code Ctrl+P style flat search across all tmux entities. Instead of the traditional hierarchical navigation (category → action → target), users can search and execute any command in a single step.

## Motivation

The current tmux-fzf workflow requires 2-3 steps:
1. Select category (session/window/pane)
2. Select action (switch/kill/rename/etc.)
3. Select target

This PR introduces a flat command palette where all actions are pre-expanded with their targets, enabling **one-step execution**:
- `[S] switch main` → switch to session "main"
- `[W] kill dev:0` → kill window 0 in session "dev"
- `[P] zoom 0:1.2` → zoom pane 2 in window 1

## Changes

### New Files

| File | Description |
|------|-------------|
| `scripts/unified.sh` | Main unified palette with flat action×target list and preview support |
| `scripts/.utils` | Common utility functions to reduce code duplication |

### Modified Files

| File | Changes |
|------|---------|
| `scripts/session.sh` | Added `$2` parameter for pre-selected target |
| `scripts/window.sh` | Added `$2` parameter, refactored with `.utils` |
| `scripts/pane.sh` | Added `$2` parameter, added `zoom` to action menu |

### Utility Functions (`.utils`)

- `prompt_name()` - Input prompt with 30s timeout to prevent hanging
- `select_swap_target()` - Swap target selection with exclusion
- `break_pane_to_window()` - Break pane to new window
- `get_current_session()` - Get current session name
- `select_source_window()` - Source window selection for link/move

## Features

- **Flat search**: All commands visible and searchable in one fzf list
- **Preview support**: See pane/window content while browsing
- **`[current]` support**: Target current session/window/pane
- **Backward compatible**: Original scripts work independently without changes
- **DRY improvement**: Common logic extracted to `.utils`, reducing ~40 lines of duplication

## Usage

```bash
# Add to .tmux.conf
bind-key P run-shell -b "~/.tmux/plugins/tmux-fzf/scripts/unified.sh"
```

## Screenshot

```
Tmux Command Palette  [S]ession [W]indow [P]ane
> [S] switch main        # (2 win)
  [S] switch dev         # * (1 win)
  [S] kill main
  [S] rename [current]   # -> input new name
  [W] switch main:0      # vim *
  [W] kill dev:0         # zsh
  [W] swap main:1        # -> select another
  [P] zoom 0:1.0         # nvim *
  [P] break 0:1.1        # -> new window
  [P] layout             # -> select layout
  ...
```

## Testing

- [x] Session: switch, kill, rename, new, detach
- [x] Window: switch, kill, rename, swap, link, move, new, split-h, split-v
- [x] Pane: switch, kill, zoom, break, swap, join, layout, resize
- [x] `[current]` target for all applicable actions
- [x] Original scripts work when called directly
- [x] Syntax validation (`bash -n`) passed
- [x] Code review passed (style aligned with original codebase)
