### PR TITLE
feat: support tmux option for launch key

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,20 @@ For example, to use `prefix` + `C-f` (Ctrl+F), add this line to your `~/.tmux.co
 TMUX_FZF_LAUNCH_KEY="C-f"
 ```
 
+You can also configure the launch key with a tmux option. This is useful when
+you prefer keeping plugin settings in tmux's option style:
+
+```tmux
+set -g @tmux-fzf-launch-key 'g'
+```
+
+The `TMUX_FZF_LAUNCH_KEY` environment variable takes precedence over the tmux
+option. If neither is set, tmux-fzf uses `prefix` + `F` by default.
+
+When choosing a key, avoid tmux's built-in default bindings unless you intend to
+override them. For example, `prefix` + `l` switches to the last window in tmux's
+default key bindings, while keys such as `g` or `C-f` are often safer choices.
+
 ## Fzf Behavior
 
 This plugin will read [fzf environment variables](https://github.com/junegunn/fzf/#environment-variables), so you can use these variables to customize the behavior of fzf (e.g. prompt and color).

--- a/main.tmux
+++ b/main.tmux
@@ -6,5 +6,14 @@ if [ -x "$(command -v copyq)" ]; then
   copyq &>/dev/null &
 fi
 
-[ -z "$TMUX_FZF_LAUNCH_KEY" ] && TMUX_FZF_LAUNCH_KEY="F"
+tmux_fzf_launch_key_option="$(tmux show-option -gqv @tmux-fzf-launch-key)"
+
+if [ -z "$TMUX_FZF_LAUNCH_KEY" ]; then
+  if [ -n "$tmux_fzf_launch_key_option" ]; then
+    TMUX_FZF_LAUNCH_KEY="$tmux_fzf_launch_key_option"
+  else
+    TMUX_FZF_LAUNCH_KEY="F"
+  fi
+fi
+
 tmux bind-key "$TMUX_FZF_LAUNCH_KEY" run-shell -b "$CURRENT_DIR/main.sh"


### PR DESCRIPTION
## Summary

This PR adds a tmux-native option for configuring the tmux-fzf launch key while keeping all existing behavior intact.

Today, tmux-fzf supports configuring the launch key through the shell environment variable `TMUX_FZF_LAUNCH_KEY`. That works, but users who manage tmux plugins primarily through `set -g @plugin-option ...` style settings may reasonably expect the launch key to be configurable as a tmux option too. This PR adds that option without removing or changing the existing environment-variable flow.

## New Feature

- Adds support for `@tmux-fzf-launch-key`.
- Allows users to configure the tmux-fzf launch key directly in `.tmux.conf` with normal tmux option syntax:

```tmux
set -g @tmux-fzf-launch-key 'g'
```

- Keeps the existing `TMUX_FZF_LAUNCH_KEY` environment variable fully supported.
- Keeps the existing default binding unchanged: if no custom setting is provided, tmux-fzf still binds to `prefix + F`.

## Precedence

The launch key is resolved in this order:

1. `TMUX_FZF_LAUNCH_KEY` environment variable, if set.
2. `@tmux-fzf-launch-key` tmux option, if set.
3. Existing default fallback: `F`.

This means existing users who already configure `TMUX_FZF_LAUNCH_KEY` will see no behavior change. The new tmux option only applies when the environment variable is not set.

## Why This Helps

Many tmux plugin settings are configured as tmux options in `.tmux.conf`, for example with `set -g @plugin-option value`. Supporting `@tmux-fzf-launch-key` makes the launch key fit that pattern and keeps related tmux-fzf configuration in one place.

This is also helpful for setups where environment variables are harder to reason about across login shells, tmux server restarts, plugin manager reloads, or shared dotfile configs.

## Backward Compatibility

This PR is intentionally conservative:

- Existing `TMUX_FZF_LAUNCH_KEY` users keep the exact same behavior.
- Users with no custom launch-key config still get `prefix + F`.
- No command names, scripts, default order, fzf options, or picker behavior are changed.
- The new option is only read as a fallback when the existing environment variable is empty.

## Documentation

The README now documents:

- How to configure the new tmux option.
- The precedence between `TMUX_FZF_LAUNCH_KEY`, `@tmux-fzf-launch-key`, and the default `F`.
- A warning to avoid overriding common tmux built-in defaults unless intentional.
- Safer example keys such as `g` or `C-f`.

The docs avoid recommending `prefix + l` because tmux uses that by default for last-window.

## Verification

- Ran shell syntax validation:

```sh
bash -n main.tmux main.sh scripts/*.sh
```

- Exercised launch-key precedence with a fake `tmux` shell wrapper:

```sh
# tmux option only -> binds g
TEST_TMUX_OPTION=g TMUX_FZF_LAUNCH_KEY= bash main.tmux

# env var wins over tmux option -> binds C-f
TEST_TMUX_OPTION=g TMUX_FZF_LAUNCH_KEY=C-f bash main.tmux

# neither env var nor tmux option -> binds F
TEST_TMUX_OPTION= TMUX_FZF_LAUNCH_KEY= bash main.tmux
```

Observed behavior:

```text
bind-key:g
bind-key:C-f
bind-key:F
```

This confirms the intended precedence and preserves the existing default fallback.