### PR TITLE
feat: pin client-dependent commands to the invoking client via TMUX_FZF_CLIENT

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,18 @@ When using the window listing script, it is possible to filter its output. This 
 
 To use this filtering feature, set the variable `TMUX_FZF_WINDOW_FILTER` to the filter you want to apply before calling the `window.sh` script. 
 
+## Multiple Attached Clients
+
+When several tmux clients are attached to the same server (e.g. two terminals), tmux commands that need a client context have to know *which* client opened the menu. Since the scripts are executed detached via `run-shell -b`, tmux would otherwise fall back to the most recently active client - which may be the other terminal. This can make `switch` act on the wrong screen and may cause intermittent `'... returned 1'` errors.
+
+To pin all client-dependent commands to the client that opened the menu, the default launch key binding passes `#{client_tty}` via `$TMUX_FZF_CLIENT` automatically. If you call the scripts from your own key bindings, pass it yourself:
+
+```tmux
+bind-key a run-shell -b "TMUX_FZF_CLIENT='#{client_tty}' ~/.tmux/plugins/tmux-fzf/scripts/session.sh switch"
+```
+
+If `$TMUX_FZF_CLIENT` is unset, the behavior is unchanged (most recently active client).
+
 # FAQ
 
 **Q: Why use environment variables instead of tmux options to customize this plugin?**

--- a/main.sh
+++ b/main.sh
@@ -7,7 +7,7 @@ source "$CURRENT_DIR/scripts/.envs"
 items_origin="$(echo $TMUX_FZF_ORDER | tr '|' '\n')"
 
 # remove copy-mode from options if we aren't in copy-mode
-if [ "$(tmux display-message -p '#{pane_in_mode}')" -eq 0 ]; then
+if [ "$(tmux display-message -p $TMUX_FZF_CLIENT_ARG '#{pane_in_mode}')" -eq 0 ]; then
     items_origin="$(echo "${items_origin}" | sed '/copy-mode/d')"
 fi
 
@@ -17,4 +17,4 @@ fi
 items_origin+=$'\n[cancel]'
 item=$(echo "${items_origin}" | $TMUX_FZF_BIN $TMUX_FZF_OPTIONS )
 [[ "$item" == "[cancel]" || -z "$item" ]] && exit
-tmux run-shell -b "$CURRENT_DIR/scripts/${item}.sh"
+tmux run-shell -b "TMUX_FZF_CLIENT='$TMUX_FZF_CLIENT' $CURRENT_DIR/scripts/${item}.sh"

--- a/main.tmux
+++ b/main.tmux
@@ -7,4 +7,4 @@ if [ -x "$(command -v copyq)" ]; then
 fi
 
 [ -z "$TMUX_FZF_LAUNCH_KEY" ] && TMUX_FZF_LAUNCH_KEY="F"
-tmux bind-key "$TMUX_FZF_LAUNCH_KEY" run-shell -b "$CURRENT_DIR/main.sh"
+tmux bind-key "$TMUX_FZF_LAUNCH_KEY" run-shell -b "TMUX_FZF_CLIENT='#{client_tty}' $CURRENT_DIR/main.sh"

--- a/scripts/.envs
+++ b/scripts/.envs
@@ -45,6 +45,14 @@ else
   [ -z "$TMUX_FZF_OPTIONS" ] && TMUX_FZF_OPTIONS="-m"
 fi
 
+# $TMUX_FZF_CLIENT_ARG
+# Commands executed via "tmux run-shell -b" have no client context, so tmux
+# falls back to the most recently active client - which may be a different
+# terminal when multiple clients are attached. When $TMUX_FZF_CLIENT is set,
+# all client-dependent commands are pinned to that client via -c.
+TMUX_FZF_CLIENT_ARG=""
+[ -n "$TMUX_FZF_CLIENT" ] && TMUX_FZF_CLIENT_ARG="-c $TMUX_FZF_CLIENT"
+
 # Unset temporary variables and functions.
 unset \
   current_dir \

--- a/scripts/pane.sh
+++ b/scripts/pane.sh
@@ -3,8 +3,8 @@
 CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$CURRENT_DIR/.envs"
 
-current_pane_origin=$(tmux display-message -p '#S:#{window_index}.#{pane_index}: #{window_name}')
-current_pane=$(tmux display-message -p '#S:#{window_index}.#{pane_index}')
+current_pane_origin=$(tmux display-message -p $TMUX_FZF_CLIENT_ARG '#S:#{window_index}.#{pane_index}: #{window_name}')
+current_pane=$(tmux display-message -p $TMUX_FZF_CLIENT_ARG '#S:#{window_index}.#{pane_index}')
 
 if [[ -z "$TMUX_FZF_PANE_FORMAT" ]]; then
     panes=$(tmux list-panes -a -F "#S:#{window_index}.#{pane_index}: [#{window_name}:#{pane_title}] #{pane_current_command}  [#{pane_width}x#{pane_height}] [history #{history_size}/#{history_limit}, #{history_bytes} bytes] #{?pane_active,[active],[inactive]}")
@@ -66,7 +66,7 @@ else
     [[ "$target_origin" == "[cancel]" || -z "$target_origin" ]] && exit
     target=$(echo "$target_origin" | sed 's/: .*//')
     if [[ "$action" == "switch" ]]; then
-        echo "$target" | sed -E 's/:.*//g' | xargs -I{} tmux switch-client -t {}
+        echo "$target" | sed -E 's/:.*//g' | xargs -I{} tmux switch-client $TMUX_FZF_CLIENT_ARG -t {}
         echo "$target" | sed -E 's/\..*//g' | xargs -I{} tmux select-window -t {}
         echo "$target" | xargs -I{} tmux select-pane -t {}
     elif [[ "$action" == "kill" ]]; then
@@ -81,7 +81,7 @@ else
     elif [[ "$action" == "join" ]]; then
         echo "$target" | sort -r | xargs -I{} tmux move-pane -s {}
     elif [[ "$action" == "break" ]]; then
-        cur_ses=$(tmux display-message -p | sed -e 's/^.//' -e 's/].*//')
+        cur_ses=$(tmux display-message -p $TMUX_FZF_CLIENT_ARG | sed -e 's/^.//' -e 's/].*//')
         last_win_num=$(tmux list-windows | sort -nr | head -1 | sed 's/:.*//')
         ((last_win_num_after = last_win_num + 1))
         tmux break-pane -s "$target" -t "$cur_ses":"$last_win_num_after"

--- a/scripts/session.sh
+++ b/scripts/session.sh
@@ -10,7 +10,7 @@ else
 fi
 
 if [[ -z "$TMUX_FZF_SWITCH_CURRENT" ]]; then
-    current_session=$(tmux display-message -p | sed -e 's/^\[//' -e 's/\].*//')
+    current_session=$(tmux display-message -p $TMUX_FZF_CLIENT_ARG | sed -e 's/^\[//' -e 's/\].*//')
     sessions=$(echo "$sessions" | grep -v "^$current_session: ")
 fi
 
@@ -43,7 +43,7 @@ if [[ "$action" != "detach" ]]; then
             exit
         fi
         if [[ "$action" == "new" ]]; then
-            tmux new-session -d -s "$session_name" && tmux switch-client -t "$session_name"
+            tmux new-session -d -s "$session_name" && tmux switch-client $TMUX_FZF_CLIENT_ARG -t "$session_name"
             exit
         fi
     fi
@@ -57,7 +57,7 @@ fi
 [[ "$target_origin" == "[cancel]" || -z "$target_origin" ]] && exit
 target=$(echo "$target_origin" | sed -e 's/:.*$//')
 if [[ "$action" == "switch" ]]; then
-    tmux switch-client -t "$target"
+    tmux switch-client $TMUX_FZF_CLIENT_ARG -t "$target"
 elif [[ "$action" == "detach" ]]; then
     echo "$target" | xargs -I{} tmux detach -s "{}"
 elif [[ "$action" == "kill" ]]; then

--- a/scripts/window.sh
+++ b/scripts/window.sh
@@ -3,8 +3,8 @@
 CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$CURRENT_DIR/.envs"
 
-current_window_origin=$(tmux display-message -p '#S:#I: #{window_name}')
-current_window=$(tmux display-message -p '#S:#I:')
+current_window_origin=$(tmux display-message -p $TMUX_FZF_CLIENT_ARG '#S:#I: #{window_name}')
+current_window=$(tmux display-message -p $TMUX_FZF_CLIENT_ARG '#S:#I:')
 
 if [[ -z  "$TMUX_FZF_WINDOW_FILTER" ]]; then
   window_filter="-a"
@@ -28,7 +28,7 @@ fi
 
 [[ "$action" == "[cancel]" || -z "$action" ]] && exit
 if [[ "$action" == "link" ]]; then
-    cur_ses=$(tmux display-message -p | sed -e 's/^.//' -e 's/].*//')
+    cur_ses=$(tmux display-message -p $TMUX_FZF_CLIENT_ARG | sed -e 's/^.//' -e 's/].*//')
     last_win_num=$(tmux list-windows | sort -r | sed '2,$d' | sed 's/:.*//')
     windows=$(echo "$windows" | grep -v "^$cur_ses")
     FZF_DEFAULT_OPTS="$FZF_DEFAULT_OPTS --header='Select source window.'"
@@ -37,7 +37,7 @@ if [[ "$action" == "link" ]]; then
     src_win=$(echo "$src_win_origin" | sed 's/: .*//')
     tmux link-window -a -s "$src_win" -t "$cur_ses"
 elif [[ "$action" == "move" ]]; then
-    cur_ses=$(tmux display-message -p | sed -e 's/^.//' -e 's/].*//')
+    cur_ses=$(tmux display-message -p $TMUX_FZF_CLIENT_ARG | sed -e 's/^.//' -e 's/].*//')
     last_win_num=$(tmux list-windows | sort -r | sed '2,$d' | sed 's/:.*//')
     windows=$(echo "$windows" | grep -v "^$cur_ses")
     FZF_DEFAULT_OPTS="$FZF_DEFAULT_OPTS --header='Select source window.'"
@@ -81,7 +81,7 @@ else
         target_swap=$(echo "$target_swap_origin" | sed 's/: .*//')
         tmux swap-window -s "$target" -t "$target_swap"
     elif [[ "$action" == "switch" ]]; then
-        echo "$target" | sed 's/:.*//g' | xargs -I{} tmux switch-client -t {}
+        echo "$target" | sed 's/:.*//g' | xargs -I{} tmux switch-client $TMUX_FZF_CLIENT_ARG -t {}
         echo "$target" | xargs -I{} tmux select-window -t {}
     fi
 fi


### PR DESCRIPTION
## Problem

All scripts are launched detached via `tmux run-shell -b`, which has **no client context**. Every client-dependent tmux call then falls back to the *most recently active client*:

- `switch-client` in `session.sh` / `window.sh` / `pane.sh`
- the current session/window/pane detection via `display-message` (used for filtering and `[current]` substitution)

With two or more attached clients (e.g. two terminals on the same server), this leads to:

- **`switch` acting on the other terminal** — the screen you are actually looking at doesn't change
- intermittent **`'…/session.sh switch' returned 1`** errors
- the wrong entry being filtered as "current"

Reproducer: attach two clients to one server, type in client A so it becomes most-recent, then use `session.sh switch` from client B — the switch (and the current-session detection) targets A instead of B.

## Solution

Introduce `TMUX_FZF_CLIENT`: when set, all client-dependent commands are pinned to that client via `-c` (assembled once as `TMUX_FZF_CLIENT_ARG` in `.envs`).

- **`main.tmux`**: the default launch key binding passes `#{client_tty}` automatically (`run-shell` expands formats against the pressing client), so menu users get this out of the box.
- **`main.sh`**: forwards the variable when dispatching to the action scripts, and uses it for its own `pane_in_mode` check.
- **`session.sh` / `window.sh` / `pane.sh`**: `display-message` and `switch-client` use the pinned client (including the `new` action in `session.sh`).
- **README**: new section "Multiple Attached Clients" documenting the variable for custom bindings.

Fully backwards compatible: when `TMUX_FZF_CLIENT` is unset, behavior is exactly as before.

## Tested

- tmux 3.7b (macOS), two attached clients: confirmed detached commands previously resolved to the wrong client; with `-c "$TMUX_FZF_CLIENT"` resolution is deterministic.
- `bash -n` on all touched scripts; verified `run-shell -b "TMUX_FZF_CLIENT='#{client_tty}' …"` expands to the pressing client.