### PR TITLE
fix: kill and switch windows fail when session/window names contain spaces or special characters

### DIFF
--- a/scripts/window.sh
+++ b/scripts/window.sh
@@ -63,7 +63,7 @@ else
     [[ "$target_origin" == "[cancel]" || -z "$target_origin" ]] && exit
     target=$(echo "$target_origin" | sed 's/: .*//')
     if [[ "$action" == "kill" ]]; then
-        echo "$target" | sort -r | xargs -I{} tmux unlink-window -k -t {}
+        echo "$target" | sort -r | while IFS= read -r w; do tmux unlink-window -k -t "$w"; done
     elif [[ "$action" == "rename" ]]; then
         mkfifo /tmp/tmux_fzf_window_name
         tmux split-window -v -l 30% -b "bash -c 'printf \"Window Name: \" && read window_name && echo \"\$window_name\" > /tmp/tmux_fzf_window_name'" &
@@ -81,7 +81,8 @@ else
         target_swap=$(echo "$target_swap_origin" | sed 's/: .*//')
         tmux swap-window -s "$target" -t "$target_swap"
     elif [[ "$action" == "switch" ]]; then
-        echo "$target" | sed 's/:.*//g' | xargs -I{} tmux switch-client $TMUX_FZF_CLIENT_ARG -t {}
-        echo "$target" | xargs -I{} tmux select-window -t {}
+        switch_session=${target%%:*}
+        tmux switch-client $TMUX_FZF_CLIENT_ARG -t "$switch_session"
+        tmux select-window -t "$target"
     fi
 fi


### PR DESCRIPTION
## Problem

`window.sh` pipes selected session/window targets through `xargs -I{}` for the `kill` and `switch` actions. `xargs -I{}` silently strips leading whitespace from each input line and treats quote/backslash characters as significant. Names with leading padding (e.g. an icon glyph followed by spaces) get truncated before reaching `tmux`, and a literal quote in a name aborts the whole invocation with `unmatched quote`. Either way, `kill`/`switch` fail or target the wrong window.

## Solution

- `kill`: replace the `xargs -I{}` pipeline with a plain `while IFS= read -r` loop, passing each target to `tmux unlink-window` quoted as-is.
- `switch`: use parameter expansion (`${target%%:*}`) to derive the session instead of piping through `sed`/`xargs`, and call `tmux switch-client`/`select-window` directly with quoted arguments.
- Kept `$TMUX_FZF_CLIENT_ARG` on `switch-client` so this doesn't regress the multi-client pinning from #103.

## Tested

- `bash -n scripts/window.sh`
- Manually verified kill/switch against session and window names containing spaces and leading padding.